### PR TITLE
feat: add support for specifying organization name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,17 +28,20 @@ inputs:
   repository_level:
     description: "Set to true to enable repository level registration token"
     default: "false"
+  organization:
+    description: "Name of the organization if github.organization is not available"
+    default: ""
 runs:
   using: "composite"
   steps:
     - run: |
         # Determine the level and runner scope based on inputs
-        if  [[ "${{ inputs.repository_level }}" == "true" ]] || [[ -z "${{ github.organization }}" ]]; then
+        if  [[ "${{ inputs.repository_level }}" == "true" ]]; then
           level="repos"
           runner_scope="${{ github.repository }}"
         else
           level="orgs"
-          runner_scope="${{ github.organization }}"
+          runner_scope="${{ inputs.organization }}"
         fi
         # Get the registration token
         registration_token=$(curl -fsSL \


### PR DESCRIPTION
This allows metal-runner-action to be used in the workflows triggered by events like `issue_comment` where the `github.organization` context might not be available. The workflow can now explicitly pass the organization name to be used.